### PR TITLE
Fixed linked libraries to be the last argument of CC command.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PREFIX=/usr
 
 
 $(TARGET): $(OBJS)
-	$(CC) $(LDFLAGS) -o $@ $^
+	$(CC) -o $@ $^ $(LDFLAGS)
 
 %.o: src/%.c
 	$(CC) -c $(CFLAGS) -o $@ $<


### PR DESCRIPTION
Hi,

the Makefile did not work on my 14.04 ubuntu server, it failed to link the curses lib.
I remember from school that the correct order of arguments puts the libs as the
last argument, which really did the job.

Great work btw, I really like what you've done. (I hate scripting ..)
