### PR TITLE
Fix incorrect printf of uint64_t

### DIFF
--- a/src/xxxid_info.c
+++ b/src/xxxid_info.c
@@ -8,6 +8,7 @@
 #include <unistd.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <inttypes.h>
 #include <sys/socket.h>
 #include <linux/taskstats.h>
 #include <linux/genetlink.h>
@@ -219,8 +220,8 @@ inline void nl_term(void)
 
 inline void dump_xxxid_stats(struct xxxid_stats *stats)
 {
-    printf("%i %i SWAPIN: %lu IO: %lu "
-           "READ: %lu WRITE: %lu IOPRIO: %s   %s\n",
+    printf("%i %i SWAPIN: %" PRIu64 " IO: %" PRIu64 " "
+           "READ: %" PRIu64 " WRITE: %" PRIu64 " IOPRIO: %s   %s\n",
            stats->tid, stats->euid,
            stats->swapin_delay_total,
            stats->blkio_delay_total, stats->read_bytes,


### PR DESCRIPTION
Affects currently unused code on 32-bit machines. Probably, it would be better to just remove this function.