### PR TITLE
[security] Fix OOB access on reading /proc

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -25,7 +25,7 @@ inline const char *xprintf(const char *format, ...)
 
 inline const char *read_cmdline2(int pid)
 {
-    static char buf[BUFSIZ];
+    static char buf[BUFSIZ + 1];
     FILE *fp = fopen(xprintf("/proc/%d/cmdline", pid), "rb");
     char *rv = NULL;
 


### PR DESCRIPTION
When argv0 in /proc/*/cmdline is larger than BUFSIZ, it triggers OOB
access.
Has security implications, especially since iotop runs with elevated
privileges. Can be triggered by unprivileged user.
Reproducer (assumes BUFSIZ is 8192):
```
make CFLAGS="-O2 -D_FORTIFY_SOURCE=2"
perl -e '$x="@" x 8192;$x .= "/$x";exec {"sleep"} $x, "10m"' ` &
sudo ./iotop
```