### PR TITLE
modify the version of libncursesw in ubuntu when compiling the source code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Please note that the installation and the usage of this program require root acc
 
 Use the following commands (note that `-y` disables confirmation prompts):
   
-    apt install git build-essential libncurses-dev pkg-config -y
+    apt install git build-essential libncursesw5-dev pkg-config -y
     git clone https://github.com/Tomas-M/iotop
     cd iotop
     make -j


### PR DESCRIPTION
When i run "make -j",there occurring:
Package ncursesw was not found in the pkg-config search path.
Perhaps you should add the directory containing `ncursesw.pc'
to the PKG_CONFIG_PATH environment variable
No package 'ncursesw' found

So i replaced libncurses-dev with libncursesw5-dev,and it works.
 
My runtime info:
ubuntu 18.04
g++ 7.5.0