### PR TITLE
view_curses: do not force black background

### DIFF
--- a/src/view_curses.c
+++ b/src/view_curses.c
@@ -1672,6 +1672,7 @@ inline void view_curses_init(void) {
 	curs_set(FALSE);
 	nodelay(stdscr,TRUE);
 	start_color();
+	use_default_colors();
 	init_pair(RED_PAIR,COLOR_RED,COLOR_BLACK);
 	init_pair(CYAN_PAIR,COLOR_CYAN,COLOR_BLACK);
 


### PR DESCRIPTION
Without a call to use_default_colors, ncurses will assume that color 0
(usually black) is the same as the background color of the terminal.

This assumption is not necessarily true, the user might be running a
terminal with any background (even white or a light color) while the
color palette has black at index 0.

To avoid overriding the background color for the entire window without a
good reason, invoke use_default_colors after start_color.