### PR TITLE
WIP: add support for DEC SCAN x characters

### DIFF
--- a/src/iotop.h
+++ b/src/iotop.h
@@ -70,9 +70,17 @@ typedef union {
 		int sort_order;
 		int base; // 1000 or 1024
 		int threshold; // 1..10
+		int charset;
 	} f;
 	int opts[22];
 } config_t;
+
+
+// character sets for pseudographics
+enum {
+	CHARSET_ASCII,
+	CHARSET_97531
+};
 
 typedef struct {
 	int iter;
@@ -280,4 +288,3 @@ inline void config_file_free(void);
 inline int config_file_save(void);
 
 #endif // __IOTOP_H__
-

--- a/src/iotop.h
+++ b/src/iotop.h
@@ -78,6 +78,7 @@ typedef union {
 
 // character sets for pseudographics
 enum {
+	CHARSET_BRAILLE,
 	CHARSET_ASCII,
 	CHARSET_97531
 };

--- a/src/main.c
+++ b/src/main.c
@@ -134,7 +134,7 @@ static inline void print_help(void) {
 		"      --threshold=1..10  threshold to switch to next unit\n"
 		"      --ascii            disable using Unicode\n"
 		"      --unicode          use Unicode drawing chars\n"
-		"      --97531            selects DEC Special Graphics Characters\n"
+		"      --97531            selects DEC special graphics characters\n"
 		"  -W, --write            write preceding options to the config and exit\n",
 		progname
 	);

--- a/src/main.c
+++ b/src/main.c
@@ -47,6 +47,7 @@ You should have received a copy of the GNU General Public License along with thi
 #define OPT_UNICODE 0x115
 #define OPT_COLOR 0x116
 #define OPT_NO_ACCUM_BW 0x117
+#define OPT_97531 0x118
 
 static const char *progname=NULL;
 int maxpidlen=5;
@@ -224,6 +225,7 @@ static inline void parse_args(int clac,char **clav) {
 				{"no-si",no_argument,NULL,OPT_NO_SI},
 				{"threshold",required_argument,NULL,OPT_THR},
 				{"ascii",no_argument,NULL,OPT_ASCII},
+				{"97531",no_argument,NULL,OPT_97531},
 				{"unicode",no_argument,NULL,OPT_UNICODE},
 				{"write",no_argument,NULL,'W'},
 				{NULL,0,NULL,0}
@@ -344,6 +346,11 @@ static inline void parse_args(int clac,char **clav) {
 					break;
 				case OPT_ASCII:
 					config.f.unicode=0;
+					config.f.charset=CHARSET_ASCII;
+					break;
+				case OPT_97531:
+					config.f.unicode=0;
+					config.f.charset=CHARSET_97531;
 					break;
 				case OPT_NO_ONLY:
 					config.f.only=0;

--- a/src/main.c
+++ b/src/main.c
@@ -134,6 +134,7 @@ static inline void print_help(void) {
 		"      --threshold=1..10  threshold to switch to next unit\n"
 		"      --ascii            disable using Unicode\n"
 		"      --unicode          use Unicode drawing chars\n"
+		"      --97531            selects DEC Special Graphics Characters\n"
 		"  -W, --write            write preceding options to the config and exit\n",
 		progname
 	);

--- a/src/main.c
+++ b/src/main.c
@@ -151,6 +151,7 @@ static inline void parse_args(int clac,char **clav) {
 	config.f.base=1024; // use non-SI units by default
 	config.f.threshold=2; // default threshold is 2*base
 	config.f.unicode=1; // default is unicode
+	config.f.charset=CHARSET_BRAILLE; // default is Braille
 
 	// implement https://no-color.org/ proposal
 	if (no_color&&*no_color)

--- a/src/view_curses.c
+++ b/src/view_curses.c
@@ -670,16 +670,16 @@ static inline void view_curses(struct xxxid_stats_arr *cs,struct xxxid_stats_arr
 			strcat(pg_t_w,br_graph[value2scale(hist_t_w[j*2],mx_t_w)][value2scale(hist_t_w[j*2+gi],mx_t_w)]);
 			strcat(pg_a_r,br_graph[value2scale(hist_a_r[j*2],mx_a_r)][value2scale(hist_a_r[j*2+gi],mx_a_r)]);
 			strcat(pg_a_w,br_graph[value2scale(hist_a_w[j*2],mx_a_w)][value2scale(hist_a_w[j*2+gi],mx_a_w)]);
-		} else if (!config.f.unicode&&config.f.charset==CHARSET_ASCII) {
-			strcat(pg_t_r,as_graph[value2scale(hist_t_r[j],mx_t_r)]);
-			strcat(pg_t_w,as_graph[value2scale(hist_t_w[j],mx_t_w)]);
-			strcat(pg_a_r,as_graph[value2scale(hist_a_r[j],mx_a_r)]);
-			strcat(pg_a_w,as_graph[value2scale(hist_a_w[j],mx_a_w)]);
 		} else if (!config.f.unicode&&config.f.charset==CHARSET_97531) {
 			strcat(pg_t_r,dec_graph[value2scale(hist_t_r[j],mx_t_r)]);
 			strcat(pg_t_w,dec_graph[value2scale(hist_t_w[j],mx_t_w)]);
 			strcat(pg_a_r,dec_graph[value2scale(hist_a_r[j],mx_a_r)]);
 			strcat(pg_a_w,dec_graph[value2scale(hist_a_w[j],mx_a_w)]);
+		} else {
+			strcat(pg_t_r,as_graph[value2scale(hist_t_r[j],mx_t_r)]);
+			strcat(pg_t_w,as_graph[value2scale(hist_t_w[j],mx_t_w)]);
+			strcat(pg_a_r,as_graph[value2scale(hist_a_r[j],mx_a_r)]);
+			strcat(pg_a_w,as_graph[value2scale(hist_a_w[j],mx_a_w)]);
 		}
 	}
 

--- a/src/view_curses.c
+++ b/src/view_curses.c
@@ -665,7 +665,7 @@ static inline void view_curses(struct xxxid_stats_arr *cs,struct xxxid_stats_arr
 	ge=config.f.reverse_graph?0:gr_width_h-1;
 	gi=config.f.reverse_graph?-1:1;
 	for (j=gs;ge<gs?j>=ge:j<=ge;j+=gi) {
-		if (has_unicode&&config.f.unicode) {
+		if (has_unicode&&config.f.unicode&&config.f.charset==CHARSET_BRAILLE) {
 			strcat(pg_t_r,br_graph[value2scale(hist_t_r[j*2],mx_t_r)][value2scale(hist_t_r[j*2+gi],mx_t_r)]);
 			strcat(pg_t_w,br_graph[value2scale(hist_t_w[j*2],mx_t_w)][value2scale(hist_t_w[j*2+gi],mx_t_w)]);
 			strcat(pg_a_r,br_graph[value2scale(hist_a_r[j*2],mx_a_r)][value2scale(hist_a_r[j*2+gi],mx_a_r)]);

--- a/src/view_curses.c
+++ b/src/view_curses.c
@@ -229,6 +229,9 @@ static const char *br_graph[5][5]={
 // ASCII pseudo graph - 1x5 levels graph per character
 static const char *as_graph[5]={" ","_",".",":","|",};
 
+// common DEC characters for graph
+static const char *dec_graph[5]={"⎽","⎼","─","⎻","⎺"};
+
 // process and threads grouping characters
 static const char *th_lines_u[8]={" ","►","┌","│","└","╭","┊","╰",};
 static const char *th_lines_a[8]={" ",">",",","|","`",",",":","`",};
@@ -667,11 +670,16 @@ static inline void view_curses(struct xxxid_stats_arr *cs,struct xxxid_stats_arr
 			strcat(pg_t_w,br_graph[value2scale(hist_t_w[j*2],mx_t_w)][value2scale(hist_t_w[j*2+gi],mx_t_w)]);
 			strcat(pg_a_r,br_graph[value2scale(hist_a_r[j*2],mx_a_r)][value2scale(hist_a_r[j*2+gi],mx_a_r)]);
 			strcat(pg_a_w,br_graph[value2scale(hist_a_w[j*2],mx_a_w)][value2scale(hist_a_w[j*2+gi],mx_a_w)]);
-		} else {
+		} else if (!config.f.unicode&&config.f.charset==CHARSET_ASCII) {
 			strcat(pg_t_r,as_graph[value2scale(hist_t_r[j],mx_t_r)]);
 			strcat(pg_t_w,as_graph[value2scale(hist_t_w[j],mx_t_w)]);
 			strcat(pg_a_r,as_graph[value2scale(hist_a_r[j],mx_a_r)]);
 			strcat(pg_a_w,as_graph[value2scale(hist_a_w[j],mx_a_w)]);
+		} else if (!config.f.unicode&&config.f.charset==CHARSET_97531) {
+			strcat(pg_t_r,dec_graph[value2scale(hist_t_r[j],mx_t_r)]);
+			strcat(pg_t_w,dec_graph[value2scale(hist_t_w[j],mx_t_w)]);
+			strcat(pg_a_r,dec_graph[value2scale(hist_a_r[j],mx_a_r)]);
+			strcat(pg_a_w,dec_graph[value2scale(hist_a_w[j],mx_a_w)]);
 		}
 	}
 
@@ -2305,4 +2313,3 @@ inline void view_curses_loop(void) {
 		k=getch();
 	}
 }
-


### PR DESCRIPTION
This adds a new switch, `--97531`, that selects characters present in the DEC Special Graphics Character Set (named "SCAN 1" through "SCAN 9", which are somewhat better supported than Braille characters.

Note: I am not totally comfortable with the interplay of `--unicode`, `--ascii`, and this switch - it could be better to just select a desired one (`--braille`, `--ascii`, `--97531`) and let iotop decide whether it can honor the selection or fallback to ASCII if the terminal can't display Unicode. That, however, would break the current conventions.

Also, I'm not sure I still like the 97531 name - perhaps "decsg" would be a better name, as it's called "DEC Special Graphics" in https://vt100.net/docs/vt510-rm/SCS.html.