### PR TITLE
src/iotop: correct pg_cb signature

### DIFF
--- a/src/iotop.h
+++ b/src/iotop.h
@@ -187,7 +187,7 @@ inline int64_t monotime(void);
 inline char *u8strpadt(const char *s,ssize_t len);
 inline char *esc_low_ascii(char *p);
 
-typedef void (*pg_cb)(pid_t pid,pid_t tid,void *hint1,void *hint2);
+typedef void (*pg_cb)(pid_t pid,pid_t tid,struct xxxid_stats_arr *hint1,filter_callback hint2);
 inline void pidgen_cb(pg_cb cb,void *hint1,void *hint2);
 
 


### PR DESCRIPTION
This fixes CFI due to mismatching signatures between pg_cb and pid_cb.