### PR TITLE
Repeated statistics of total IO

### DIFF
--- a/src/views.c
+++ b/src/views.c
@@ -23,6 +23,8 @@ inline void calc_total(struct xxxid_stats_arr *cs,double *read,double *write) {
 	*read=*write=0;
 
 	for (i=0;i<cs->length;i++) {
+		if (cs->arr[i]->pid!=cs->arr[i]->tid)
+			continue;
 		if (!config.f.accumulated) {
 			*read+=cs->arr[i]->read_val;
 			*write+=cs->arr[i]->write_val;


### PR DESCRIPTION
when calc_total, the processIo = sum(child threads), so when calc, should not add tid!=pid.