### PR TITLE
Add autopkgtests

### DIFF
--- a/debian/tests/basic-output
+++ b/debian/tests/basic-output
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Smoke test for iotop-c basic output functionality.
+# Verify that iotop-c can run in batch mode and produce usable output.
+
+set -eu
+
+# Remove the known iotop-c warning about task_delayacct being disabled.
+# All other stderr output is preserved and should be treated as errors.
+filter_stderr() {
+    sed '/task_delayacct is 0/d'
+}
+
+cleanup() {
+    rm -f "$out" "$err" "$filtered_err"
+}
+trap cleanup EXIT
+
+out=$(mktemp)
+err=$(mktemp)
+filtered_err=$(mktemp)
+
+iotop-c -b -n 1 >"$out" 2>"$err" || true
+filter_stderr <"$err" >"$filtered_err"
+
+[ ! -s "$filtered_err" ]
+
+grep -q "Total DISK READ" "$out"
+grep -q "DISK WRITE" "$out"

--- a/debian/tests/control
+++ b/debian/tests/control
@@ -1,0 +1,3 @@
+Tests: basic-output iterations real-io
+Depends: iotop-c, coreutils
+Restrictions: needs-root isolation-machine

--- a/debian/tests/iterations
+++ b/debian/tests/iterations
@@ -1,0 +1,35 @@
+#!/bin/sh
+# Verify that iotop-c respects the requested iteration count
+# and exits promptly in batch mode.
+
+set -eu
+
+cleanup() {
+    rm -f "$out" "$err" "$filtered_err"
+}
+trap cleanup EXIT
+
+# Remove the known iotop-c warning about task_delayacct being disabled.
+# All other stderr output is preserved and should be treated as errors.
+filter_stderr() {
+    sed '/task_delayacct is 0/d'
+}
+
+out=$(mktemp)
+err=$(mktemp)
+filtered_err=$(mktemp)
+
+iteration_count=3
+
+iotop-c -b --iter "$iteration_count" >"$out" 2>"$err" || true
+filter_stderr <"$err" >"$filtered_err"
+
+[ ! -s "$filtered_err" ]
+
+# Count how many times the header appears
+count="$(grep -c "Total DISK READ" "$out" || true)"
+
+if [ "$count" -ne "$iteration_count" ]; then
+    echo "ERROR: Expected $iteration_count headers, but found $count" >&2
+    exit 1
+fi

--- a/debian/tests/real-io
+++ b/debian/tests/real-io
@@ -1,0 +1,50 @@
+#!/bin/sh
+# Verify that real disk I/O is detected and inactive processes
+# can be filtered.
+
+set -eu
+
+cleanup() {
+    rm -f "$out" "$err" "$filter_stderr" "$file"
+}
+trap cleanup EXIT
+
+# Remove the known iotop-c warning about task_delayacct being disabled.
+# All other stderr output is preserved and should be treated as errors.
+filter_stderr() {
+    sed '/task_delayacct is 0/d'
+}
+
+out=$(mktemp)
+err=$(mktemp)
+filter_stderr=$(mktemp)
+file=$(mktemp)
+
+iotop-c -d 0.2 -b -n 20 -o >"$out" 2>"$err" &
+iotop_pid=$!
+
+# Generate real I/O
+dd if=/dev/zero of="$file" bs=10M count=100 2>/dev/null &
+dd_pid=$!
+
+# Wait for iotop-c to finish
+wait $iotop_pid
+filter_stderr <"$err" >"$filter_stderr"
+
+[ ! -s "$filter_stderr" ]
+
+# At least one process line for dd must exist, like
+# 13847 be/4 root          0.00 B/s  693.28 M/s 0.00 % 0.00 % dd
+if ! grep -Eq "^[[:space:]]*$dd_pid[[:space:]].*dd$" "$out"; then
+    echo "ERROR: Expected a line with '$dd_pid ... dd', but did not find it in the output:" >&2
+    cat "$out" >&2
+    exit 1
+fi
+
+# No process line may have both read and write equal to zero, as in
+# 33   be/5 root         0.00 B/s    0.00 B/s ... ksmd
+if grep -Eq '^[[:space:]]*[0-9]+.*0\.00 B/s[[:space:]]+0\.00 B/s' "$out"; then
+    echo "ERROR: Found an inactive process (both read and write are zero):" >&2
+    grep -E '^[[:space:]]*[0-9]+.*0\.00 B/s[[:space:]]+0\.00 B/s' "$out" >&2
+    exit 1
+fi


### PR DESCRIPTION
This PR is adding autopkgtests to this implementation of iotop.

These are also proposed in Ubuntu, in: https://code.launchpad.net/~rr/ubuntu/+source/iotop-c/+git/iotop-c/+merge/498261

I didn't update the changelog here as I don't want to mess with versioning (: Let me know if you want me to do this.